### PR TITLE
Use #to_pem instead of #to_s

### DIFF
--- a/lib/mini_ca/certificate.rb
+++ b/lib/mini_ca/certificate.rb
@@ -111,19 +111,19 @@ module MiniCa
     end
 
     def x509_pem
-      x509.to_s
+      x509.to_pem
     end
 
     def chain_pem
-      chain.map(&:x509).map(&:to_s).join('')
+      chain.map(&:x509).map(&:to_pem).join('')
     end
 
     def bundle_pem
-      bundle.map(&:x509).map(&:to_s).join('')
+      bundle.map(&:x509).map(&:to_pem).join('')
     end
 
     def private_key_pem
-      private_key.to_s
+      private_key.to_pem
     end
   end
 end


### PR DESCRIPTION
For e.g. EC keys, #to_s does not return the PEM formatted key.