### PR TITLE
Support ECDSA private keys

### DIFF
--- a/lib/mini_ca/certificate.rb
+++ b/lib/mini_ca/certificate.rb
@@ -28,7 +28,7 @@ module MiniCa
       x509.version = 0x2
       x509.serial = serial || 0
 
-      x509.public_key = send(:private_key).public_key
+      x509.public_key = public_key
 
       x509.subject = OpenSSL::X509::Name.new
 
@@ -125,6 +125,21 @@ module MiniCa
 
     def private_key_pem
       private_key.to_pem
+    end
+
+    def public_key
+      case private_key
+      when OpenSSL::PKey::RSA
+        private_key.public_key
+      when OpenSSL::PKey::EC
+        # See: https://github.com/ruby/openssl/issues/29#issuecomment-230664793
+        # See: https://alexpeattie.com/blog/signing-a-csr-with-ecdsa-in-ruby
+        pub = OpenSSL::PKey::EC.new(private_key.group)
+        pub.public_key = private_key.public_key
+        pub
+      else
+        raise Error, "Unsupported private_key: #{private_key.class}"
+      end
     end
   end
 end

--- a/spec/mini_ca/certificate_spec.rb
+++ b/spec/mini_ca/certificate_spec.rb
@@ -53,10 +53,28 @@ describe MiniCa::Certificate do
       end
     end
 
-    it 'initializes with a custom private_key' do
+    it 'initializes with a custom private_key (RSA)' do
       k = OpenSSL::PKey::RSA.new(512)
-      expect(described_class.new('x', private_key: k).private_key_pem)
-        .to eq(k.to_pem)
+
+      crt = described_class.new('x', private_key: k)
+      expect(crt.private_key_pem).to eq(k.to_pem)
+      expect(crt.x509.check_private_key(k)).to be_truthy
+    end
+
+    it 'initializes with a custom private_key (ECDSA)' do
+      k = OpenSSL::PKey::EC.new('prime256v1').tap(&:generate_key)
+
+      # Ruby < 2.4 lacks a #private? method on EC keys, which is used when
+      # signing. We're not going to monkey-patch this for users, but we want to
+      # monkey patch it for our own specs.
+      maj, min, = RUBY_VERSION.split('.').map { |e| Integer(e) }
+      unless maj >= 2 && min >= 4 || maj > 2
+        allow(k).to receive(:private?) { k.private_key? }
+      end
+
+      crt = described_class.new('x', private_key: k)
+      expect(crt.private_key_pem).to eq(k.to_pem)
+      expect(crt.x509.check_private_key(k)).to be_truthy
     end
   end
 


### PR DESCRIPTION
Technically, this only really works well on Ruby 2.4 where EC keys have
a `#private?` method, but at least, it works there (clients on earlier
versions can opt to monkey patch).