### PR TITLE
Github action 20.04 runner EOL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,29 @@ on:
       - master
 
 jobs:
-  test:
-    name: Test
+  test-20:
+    name: Test 20
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        RUBY_VERSION: ["2.6", "3"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby ${{ matrix.RUBY_VERSION }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Run Tests
+        run: bundle exec rake
+
+  test-24:
+    name: Test 24
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -36,7 +57,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [test]
+    needs: [test-20, test-24]
     steps:
       - run: exit 1
         # see https://stackoverflow.com/a/67532120/4907315

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,57 +11,13 @@ on:
       - master
 
 jobs:
-
-  test-20:
-    name: Test 20
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        RUBY_VERSION: ["2.2", "2.3", "2.6", "3"]
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Install Ruby ${{ matrix.RUBY_VERSION }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.RUBY_VERSION }}
-          bundler-cache: true
-
-      - name: Run Tests
-        run: bundle exec rake
-
-  test-22 :
-    name: Test 22
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        RUBY_VERSION: ["2.2", "2.3", "2.6", "3"]
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Install Ruby ${{ matrix.RUBY_VERSION }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.RUBY_VERSION }}
-          bundler-cache: true
-
-      - name: Run Tests
-        run: bundle exec rake
-
-
-  test-24:
-    name: Test 24
+  test:
+    name: Test
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        RUBY_VERSION: ["2.2", "2.3", "2.6", "3"]
+        RUBY_VERSION: ["2.6", "3"]
 
     steps:
       - name: Check out code
@@ -80,7 +36,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [test-20, test-22, test-24]
+    needs: [test]
     steps:
       - run: exit 1
         # see https://stackoverflow.com/a/67532120/4907315

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,34 +11,13 @@ on:
       - master
 
 jobs:
-  test-20:
-    name: Test 20
-    runs-on: ubuntu-20.04
-    strategy:
-      fail-fast: false
-      matrix:
-        RUBY_VERSION: ["2.6", "3"]
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-
-      - name: Install Ruby ${{ matrix.RUBY_VERSION }}
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.RUBY_VERSION }}
-          bundler-cache: true
-
-      - name: Run Tests
-        run: bundle exec rake
-
-  test-24:
-    name: Test 24
+  test:
+    name: Test
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        RUBY_VERSION: ["2.6", "3"]
+        RUBY_VERSION: ["2.6", "3.3"]
 
     steps:
       - name: Check out code
@@ -57,7 +36,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [test-20, test-24]
+    needs: [test]
     steps:
       - run: exit 1
         # see https://stackoverflow.com/a/67532120/4907315

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,51 @@ on:
 
 jobs:
 
-  test:
-    name: Test
+  test-20:
+    name: Test 20
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        RUBY_VERSION: ["2.2", "2.3", "2.6", "3"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby ${{ matrix.RUBY_VERSION }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Run Tests
+        run: bundle exec rake
+
+  test-22 :
+    name: Test 22
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        RUBY_VERSION: ["2.2", "2.3", "2.6", "3"]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install Ruby ${{ matrix.RUBY_VERSION }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Run Tests
+        run: bundle exec rake
+
+
+  test-24:
+    name: Test 24
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -37,7 +80,7 @@ jobs:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Final Results
-    needs: [test]
+    needs: [test-20, test-22, test-24]
     steps:
       - run: exit 1
         # see https://stackoverflow.com/a/67532120/4907315

--- a/lib/mini_ca/certificate.rb
+++ b/lib/mini_ca/certificate.rb
@@ -28,7 +28,7 @@ module MiniCa
       x509.version = 0x2
       x509.serial = serial || 0
 
-      x509.public_key = public_key
+      x509.public_key = @private_key
 
       x509.subject = OpenSSL::X509::Name.new
 
@@ -126,21 +126,6 @@ module MiniCa
 
     def private_key_pem
       private_key.to_pem
-    end
-
-    def public_key
-      case private_key
-      when OpenSSL::PKey::RSA
-        private_key.public_key
-      when OpenSSL::PKey::EC
-        # See: https://github.com/ruby/openssl/issues/29#issuecomment-230664793
-        # See: https://alexpeattie.com/blog/signing-a-csr-with-ecdsa-in-ruby
-        pub = OpenSSL::PKey::EC.new(private_key.group)
-        pub.public_key = private_key.public_key
-        pub
-      else
-        raise Error, "Unsupported private_key: #{private_key.class}"
-      end
     end
   end
 end

--- a/lib/mini_ca/version.rb
+++ b/lib/mini_ca/version.rb
@@ -1,3 +1,3 @@
 module MiniCa
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/mini_ca.gemspec
+++ b/mini_ca.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'aptible-tasks'
+  spec.add_development_dependency 'base64'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'

--- a/spec/mini_ca/certificate_spec.rb
+++ b/spec/mini_ca/certificate_spec.rb
@@ -62,7 +62,7 @@ describe MiniCa::Certificate do
     end
 
     it 'initializes with a custom private_key (ECDSA)' do
-      k = OpenSSL::PKey::EC.new('prime256v1').tap(&:generate_key)
+      k = OpenSSL::PKey::EC.generate('prime256v1')
 
       # Ruby < 2.4 lacks a #private? method on EC keys, which is used when
       # signing. We're not going to monkey-patch this for users, but we want to

--- a/spec/mini_ca/certificate_spec.rb
+++ b/spec/mini_ca/certificate_spec.rb
@@ -64,13 +64,6 @@ describe MiniCa::Certificate do
     it 'initializes with a custom private_key (ECDSA)' do
       k = OpenSSL::PKey::EC.generate('prime256v1')
 
-      # Ruby < 2.4 lacks a #private? method on EC keys, which is used when
-      # signing. We're not going to monkey-patch this for users, but we want to
-      # monkey patch it for our own specs.
-      maj, min, = RUBY_VERSION.split('.').map { |e| Integer(e) }
-
-      allow(k).to receive(:private?) { k.private_key? } unless maj >= 2 && min >= 4 || maj > 2
-
       crt = described_class.new('x', private_key: k)
       expect(crt.private_key_pem).to eq(k.to_pem)
       expect(crt.x509.check_private_key(k)).to be_truthy


### PR DESCRIPTION
Uptades to work on OpenSSL 3 systems, since Ubuntu 20 is EOL, and 22 and 24 come with OpenSSL 3.

We also are doing something OpenSSL considers implicitly "wrong", but i don't immediately grok  why we're doing exactly what they say you cant?

We were apparently following [this referenced advice](https://alexpeattie.com/blog/signing-a-csr-with-ecdsa-in-ruby/#:~:text=We%20could%20just%20use,public%20part%20of%20ec_domain_key).

``` 
1) MiniCa::Certificate#initialize initializes with a custom private_key (ECDSA)
     Failure/Error: pub.public_key = private_key.public_key

     OpenSSL::PKey::PKeyError:
       pkeys are immutable on OpenSSL 3.0
     # ./lib/mini_ca/certificate.rb:139:in `public_key='
     # ./lib/mini_ca/certificate.rb:139:in `public_key'
     # ./lib/mini_ca/certificate.rb:31:in `initialize'
     # ./spec/mini_ca/certificate_spec.rb:74:in `new'
     # ./spec/mini_ca/certificate_spec.rb:74:in `block (3 levels) in <top (required)>'
```

... I think it's "fine" if we don't do that?