### PR TITLE
ACM requires a positive serial

### DIFF
--- a/lib/mini_ca/certificate.rb
+++ b/lib/mini_ca/certificate.rb
@@ -26,7 +26,8 @@ module MiniCa
       @counter = 0
 
       x509.version = 0x2
-      x509.serial = serial || 0
+      # https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2 — must be unique positive integer
+      x509.serial = serial || OpenSSL::BN.rand(128, 0)
 
       x509.public_key = public_key
 

--- a/lib/mini_ca/certificate.rb
+++ b/lib/mini_ca/certificate.rb
@@ -26,7 +26,8 @@ module MiniCa
       @counter = 0
 
       x509.version = 0x2
-      # https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2 — must be unique positive integer
+      # https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2
+      # must be unique positive integer
       x509.serial = serial || OpenSSL::BN.rand(128, 0)
 
       x509.public_key = public_key

--- a/lib/mini_ca/version.rb
+++ b/lib/mini_ca/version.rb
@@ -1,3 +1,3 @@
 module MiniCa
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
 end


### PR DESCRIPTION
Our integration tests use this gem for generating self signed certificates, but the tests don't specify a serial on generation so they were defaulting to `0`.

We started integration testing ACM intead of IAM for certs, and ACM rejects these certificates:

> The serial number in the certificate is not supported by ACM.

`0` is invalid per https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.2

> 4.1.2.2.  Serial Number
> 
>    The serial number MUST be a positive integer assigned by the CA to
>    each certificate.  It MUST be unique for each certificate issued by a
>    given CA (i.e., the issuer name and serial number identify a unique
>    certificate).  CAs MUST force the serialNumber to be a non-negative
>    integer.

